### PR TITLE
fix #11

### DIFF
--- a/execnb/shell.py
+++ b/execnb/shell.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from fastcore.basics import *
 from fastcore.imports import *
 from fastcore.script import call_parse
-from fastcore.test import *
 
 import tokenize
 from IPython.core.interactiveshell import InteractiveShell
@@ -21,7 +20,7 @@ from collections.abc import Callable
 # %% auto 0
 __all__ = ['CaptureShell', 'exec_nb']
 
-# %% ../nbs/02_shell.ipynb 4
+# %% ../nbs/02_shell.ipynb 5
 # IPython requires a DisplayHook and DisplayPublisher
 # We override `__call__` and `publish` to save outputs instead of printing them
 
@@ -45,12 +44,12 @@ class _CapturePub(DisplayPublisher):
     "Called when adding an output"
     def publish(self, data, metadata=None, **kwargs): self.shell._add_out(data, metadata, typ='display_data')
 
-# %% ../nbs/02_shell.ipynb 5
+# %% ../nbs/02_shell.ipynb 6
 # These are the standard notebook formats for exception and stream data (e.g stdout)
 def _out_exc(ename, evalue, traceback): return dict(ename=str(ename), evalue=str(evalue), output_type='error', traceback=traceback)
 def _out_stream(text): return dict(name='stdout', output_type='stream', text=text.splitlines(False))
 
-# %% ../nbs/02_shell.ipynb 7
+# %% ../nbs/02_shell.ipynb 8
 class CaptureShell(FastInteractiveShell):
     "Execute the IPython/Jupyter source code"
     def __init__(self,
@@ -98,7 +97,7 @@ class CaptureShell(FastInteractiveShell):
         text = std.getvalue()
         if text: self.out.append(_out_stream(text))
 
-# %% ../nbs/02_shell.ipynb 10
+# %% ../nbs/02_shell.ipynb 11
 @patch
 def run(self:CaptureShell,
         code:str, # Python/IPython code to run
@@ -116,7 +115,7 @@ def run(self:CaptureShell,
     self._stream(stdout)
     return [*self.out]
 
-# %% ../nbs/02_shell.ipynb 21
+# %% ../nbs/02_shell.ipynb 22
 @patch
 def cell(self:CaptureShell, cell, stdout=True, stderr=True):
     "Run `cell`, skipping if not code, and store outputs back in cell"
@@ -128,7 +127,7 @@ def cell(self:CaptureShell, cell, stdout=True, stderr=True):
         for o in outs:
             if 'execution_count' in o: cell['execution_count'] = o['execution_count']
 
-# %% ../nbs/02_shell.ipynb 25
+# %% ../nbs/02_shell.ipynb 26
 def _false(o): return False
 
 @patch
@@ -148,7 +147,7 @@ def run_all(self:CaptureShell,
             postproc(cell)
         if self.exc and exc_stop: raise self.exc[1] from None
 
-# %% ../nbs/02_shell.ipynb 39
+# %% ../nbs/02_shell.ipynb 40
 @patch
 def execute(self:CaptureShell,
             src:str|Path, # Notebook path to read from
@@ -169,7 +168,7 @@ def execute(self:CaptureShell,
                  inject_code=inject_code, inject_idx=inject_idx)
     if dest: write_nb(nb, dest)
 
-# %% ../nbs/02_shell.ipynb 42
+# %% ../nbs/02_shell.ipynb 43
 @patch
 def prettytb(self:CaptureShell, 
              fname:str|Path=None): # filename to print alongside the traceback
@@ -181,7 +180,7 @@ def prettytb(self:CaptureShell,
     fname_str = f' in {fname}' if fname else ''
     return f"{type(self.exc[1]).__name__}{fname_str}:\n{_fence}\n{cell_str}\n"
 
-# %% ../nbs/02_shell.ipynb 55
+# %% ../nbs/02_shell.ipynb 56
 @call_parse
 def exec_nb(
     src:str, # Notebook path to read from

--- a/nbs/02_shell.ipynb
+++ b/nbs/02_shell.ipynb
@@ -30,7 +30,6 @@
     "from fastcore.basics import *\n",
     "from fastcore.imports import *\n",
     "from fastcore.script import call_parse\n",
-    "from fastcore.test import *\n",
     "\n",
     "import tokenize\n",
     "from IPython.core.interactiveshell import InteractiveShell\n",
@@ -42,6 +41,15 @@
     "from execnb.nbio import *\n",
     "\n",
     "from collections.abc import Callable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastcore.test import *"
    ]
   },
   {
@@ -231,8 +239,8 @@
        "  'execution_count': 1},\n",
        " {'name': 'stdout',\n",
        "  'output_type': 'stream',\n",
-       "  'text': ['CPU times: user 2 us, sys: 0 ns, total: 2 us',\n",
-       "   'Wall time: 5.01 us']}]"
+       "  'text': ['CPU times: user 2 us, sys: 1 us, total: 3 us',\n",
+       "   'Wall time: 4.77 us']}]"
       ]
      },
      "execution_count": null,
@@ -816,7 +824,7 @@
     "res = CaptureShell().run('1+1;')\n",
     "test_eq(res, [])\n",
     "\n",
-    "# Newlines, whitespace, and comments after the `;` are ignored\n",
+    "# Newlines, whitespace, and comments after `;` are ignored\n",
     "res = CaptureShell().run('1+1;\\n  #commented_func()')\n",
     "test_eq(res, [])"
    ]

--- a/nbs/02_shell.ipynb
+++ b/nbs/02_shell.ipynb
@@ -30,7 +30,9 @@
     "from fastcore.basics import *\n",
     "from fastcore.imports import *\n",
     "from fastcore.script import call_parse\n",
+    "from fastcore.test import *\n",
     "\n",
+    "import tokenize\n",
     "from IPython.core.interactiveshell import InteractiveShell\n",
     "from IPython.core.displayhook import DisplayHook\n",
     "from IPython.core.displaypub import DisplayPublisher\n",
@@ -54,8 +56,17 @@
     "\n",
     "class _CaptureHook(DisplayHook):\n",
     "    \"Called when displaying a result\"\n",
+    "\n",
+    "    def quiet(self):\n",
+    "        \"Should we silence because of ';'?\"\n",
+    "        sio = StringIO(self.shell._code)\n",
+    "        tokens = list(tokenize.generate_tokens(sio.readline))\n",
+    "        for t in reversed(tokens):\n",
+    "            if t.type in (tokenize.ENDMARKER, tokenize.NL, tokenize.NEWLINE, tokenize.COMMENT): continue\n",
+    "            return t.type == tokenize.OP and t.string == ';'\n",
+    "\n",
     "    def __call__(self, result=None):\n",
-    "        if result is None: return\n",
+    "        if result is None or self.quiet(): return\n",
     "        self.fill_exec_result(result)\n",
     "        self.shell._result(result)\n",
     "\n",
@@ -220,8 +231,8 @@
        "  'execution_count': 1},\n",
        " {'name': 'stdout',\n",
        "  'output_type': 'stream',\n",
-       "  'text': ['CPU times: user 3 us, sys: 1 us, total: 4 us',\n",
-       "   'Wall time: 6.2 us']}]"
+       "  'text': ['CPU times: user 2 us, sys: 0 ns, total: 2 us',\n",
+       "   'Wall time: 5.01 us']}]"
       ]
      },
      "execution_count": null,
@@ -258,6 +269,33 @@
    ],
    "source": [
     "s.result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A trailing `;` stops the result from being captured:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s.run(\"1+2;\")"
    ]
   },
   {
@@ -759,11 +797,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#|hide\n",
     "# matplotlib images are captured when outer shell uses inline backend\n",
     "import matplotlib\n",
     "matplotlib.use('module://matplotlib_inline.backend_inline')\n",
     "res = CaptureShell().run('import matplotlib.pyplot as plt; plt.plot([0,1]);')\n",
     "assert any('image/png' in o['data'] for o in res),'Image not captured'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "# Trailing `;` stops data from being captured\n",
+    "res = CaptureShell().run('1+1;')\n",
+    "test_eq(res, [])\n",
+    "\n",
+    "# Newlines, whitespace, and comments after the `;` are ignored\n",
+    "res = CaptureShell().run('1+1;\\n  #commented_func()')\n",
+    "test_eq(res, [])"
    ]
   },
   {


### PR DESCRIPTION
This adapts IPython's [`DisplayHook.quiet`](https://github.com/ipython/ipython/blob/359181665fcc65c6ff4d76430348ca27858b0443/IPython/core/displayhook.py#L84) to silence cells with trailing `;`s.

It uses `tokenize` to ignore comments after the `;`. If we're not too worried about maintaining exact consistency, we could do something like `self.shell._code.rstrip().endswith(';')`, but I think using `tokenize` is pretty lightweight anyway.

cc @hamelsmu @jph00