### PR TITLE
`CaptureShell.shell` sets `cell.outputs` to ordinary dicts instead of `AttrDict`s

### DIFF
--- a/execnb/shell.py
+++ b/execnb/shell.py
@@ -24,6 +24,7 @@ from io import StringIO
 
 from .fastshell import FastInteractiveShell
 from .nbio import *
+from .nbio import _dict2obj
 
 from collections.abc import Callable
 
@@ -150,7 +151,7 @@ def cell(self:CaptureShell, cell, stdout=True, stderr=True):
     self._cell_idx = cell.idx_ + 1
     outs = self.run(cell.source)
     if outs:
-        cell.outputs = outs
+        cell.outputs = _dict2obj(outs)
         for o in outs:
             if 'execution_count' in o: cell['execution_count'] = o['execution_count']
 

--- a/nbs/02_shell.ipynb
+++ b/nbs/02_shell.ipynb
@@ -49,6 +49,7 @@
     "\n",
     "from execnb.fastshell import FastInteractiveShell\n",
     "from execnb.nbio import *\n",
+    "from execnb.nbio import _dict2obj\n",
     "\n",
     "from collections.abc import Callable"
    ]
@@ -441,7 +442,7 @@
     "    self._cell_idx = cell.idx_ + 1\n",
     "    outs = self.run(cell.source)\n",
     "    if outs:\n",
-    "        cell.outputs = outs\n",
+    "        cell.outputs = _dict2obj(outs)\n",
     "        for o in outs:\n",
     "            if 'execution_count' in o: cell['execution_count'] = o['execution_count']"
    ]


### PR DESCRIPTION
This causes a downstream issue in nbdev causing the `add_links` processor to skip cells created by `exec_show_docs`. For example, `TransformBlock` should be linkified in https://docs.fast.ai/vision.data.html#imageblock:

<img width="414" alt="image" src="https://user-images.githubusercontent.com/559360/192131122-0f953511-72f9-4916-9d50-5df05e4c0aa1.png">