### PR TITLE
Specify encoding when reading file in write_nb (fixes #40)

### DIFF
--- a/execnb/nbio.py
+++ b/execnb/nbio.py
@@ -91,6 +91,6 @@ def write_nb(nb, path):
     "Write `nb` to `path`"
     new = nb2str(nb)
     path = Path(path)
-    old = Path(path).read_text() if path.exists() else None
+    old = Path(path).read_text(encoding="utf-8") if path.exists() else None
     if new!=old:
         with open(path, 'w', encoding='utf-8') as f: f.write(new)


### PR DESCRIPTION
Fixes #40 by specifying the encoding when reading a notebook file for checking changes in `write_nb`.