### PR TITLE
Add option to use ansi2html renderer

### DIFF
--- a/execnb/shell.py
+++ b/execnb/shell.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from fastcore.utils import *
 from fastcore.script import call_parse
 from fastcore.ansi import ansi2html
+
 import multiprocessing,types,traceback
 try:
     if sys.platform == 'darwin': multiprocessing.set_start_method("fork")

--- a/execnb/shell.py
+++ b/execnb/shell.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from fastcore.utils import *
 from fastcore.script import call_parse
-
+from fastcore.ansi import ansi2html
 import multiprocessing,types,traceback
 try:
     if sys.platform == 'darwin': multiprocessing.set_start_method("fork")
@@ -125,11 +125,11 @@ def run(self:CaptureShell,
     return _out_nb(res, self.display_formatter)
 
 # %% ../nbs/02_shell.ipynb 30
-def render_outputs(outputs):
+def render_outputs(outputs, ansi_renderer=strip_ansi):
     def render_output(out):
         otype = out['output_type']
         if otype == 'stream':
-            txt = strip_ansi(''.join(out['text']))
+            txt = ansi_renderer(''.join(out['text']))
             return f"<pre>{txt}</pre>" if out['name']=='stdout' else f"<pre class='stderr'>{txt}</pre>"
         elif otype in ('display_data','execute_result'):
             data = out['data']
@@ -146,7 +146,7 @@ def render_outputs(outputs):
     
     return '\n'.join(map(render_output, outputs))
 
-# %% ../nbs/02_shell.ipynb 41
+# %% ../nbs/02_shell.ipynb 43
 @patch
 def cell(self:CaptureShell, cell, stdout=True, stderr=True):
     "Run `cell`, skipping if not code, and store outputs back in cell"
@@ -158,32 +158,32 @@ def cell(self:CaptureShell, cell, stdout=True, stderr=True):
         for o in outs:
             if 'execution_count' in o: cell['execution_count'] = o['execution_count']
 
-# %% ../nbs/02_shell.ipynb 44
+# %% ../nbs/02_shell.ipynb 46
 def find_output(outp, # Output from `run`
                 ot='execute_result' # Output_type to find
                ):
     "Find first output of type `ot` in `CaptureShell.run` output"
     return first(o for o in outp if o['output_type']==ot)
 
-# %% ../nbs/02_shell.ipynb 47
+# %% ../nbs/02_shell.ipynb 49
 def out_exec(outp):
     "Get data from execution result in `outp`."
     out = find_output(outp)
     if out: return '\n'.join(first(out['data'].values()))
 
-# %% ../nbs/02_shell.ipynb 49
+# %% ../nbs/02_shell.ipynb 51
 def out_stream(outp):
     "Get text from stream in `outp`."
     out = find_output(outp, 'stream')
     if out: return ('\n'.join(out['text'])).strip()
 
-# %% ../nbs/02_shell.ipynb 51
+# %% ../nbs/02_shell.ipynb 53
 def out_error(outp):
     "Get traceback from error in `outp`."
     out = find_output(outp, 'error')
     if out: return '\n'.join(out['traceback'])
 
-# %% ../nbs/02_shell.ipynb 53
+# %% ../nbs/02_shell.ipynb 55
 def _false(o): return False
 
 @patch
@@ -203,7 +203,7 @@ def run_all(self:CaptureShell,
             postproc(cell)
         if self.exc and exc_stop: raise self.exc from None
 
-# %% ../nbs/02_shell.ipynb 67
+# %% ../nbs/02_shell.ipynb 69
 @patch
 def execute(self:CaptureShell,
             src:str|Path, # Notebook path to read from
@@ -224,7 +224,7 @@ def execute(self:CaptureShell,
                  inject_code=inject_code, inject_idx=inject_idx)
     if dest: write_nb(nb, dest)
 
-# %% ../nbs/02_shell.ipynb 71
+# %% ../nbs/02_shell.ipynb 73
 @patch
 def prettytb(self:CaptureShell, 
              fname:str|Path=None): # filename to print alongside the traceback
@@ -236,7 +236,7 @@ def prettytb(self:CaptureShell,
     fname_str = f' in {fname}' if fname else ''
     return f"{type(self.exc).__name__}{fname_str}:\n{_fence}\n{cell_str}\n"
 
-# %% ../nbs/02_shell.ipynb 90
+# %% ../nbs/02_shell.ipynb 92
 @call_parse
 def exec_nb(
     src:str, # Notebook path to read from
@@ -250,7 +250,7 @@ def exec_nb(
     CaptureShell().execute(src, dest, exc_stop=exc_stop, inject_code=inject_code,
                            inject_path=inject_path, inject_idx=inject_idx)
 
-# %% ../nbs/02_shell.ipynb 93
+# %% ../nbs/02_shell.ipynb 95
 class SmartCompleter(IPCompleter):
     def __init__(self, shell, namespace=None, jedi=False):
         if namespace is None: namespace = shell.user_ns
@@ -270,7 +270,7 @@ class SmartCompleter(IPCompleter):
                     for o in self.completions(c, len(c))
                     if o.type=='<unknown>']
 
-# %% ../nbs/02_shell.ipynb 95
+# %% ../nbs/02_shell.ipynb 97
 @patch
 def complete(self:CaptureShell, c):
     if not hasattr(self, '_completer'): self._completer = SmartCompleter(self)

--- a/execnb/shell.py
+++ b/execnb/shell.py
@@ -269,7 +269,7 @@ class SmartCompleter(IPCompleter):
         with provisionalcompleter():
             return [o.text.rpartition('.')[-1]
                     for o in self.completions(c, len(c))
-                    if o.type=='<unknown>']
+                    if o.type not in ('magic', 'path')]
 
 # %% ../nbs/02_shell.ipynb 97
 @patch

--- a/nbs/02_shell.ipynb
+++ b/nbs/02_shell.ipynb
@@ -30,6 +30,7 @@
     "\n",
     "from fastcore.utils import *\n",
     "from fastcore.script import call_parse\n",
+    "from fastcore.ansi import ansi2html\n",
     "\n",
     "import multiprocessing,types,traceback\n",
     "try:\n",

--- a/nbs/02_shell.ipynb
+++ b/nbs/02_shell.ipynb
@@ -1855,7 +1855,7 @@
     "        with provisionalcompleter():\n",
     "            return [o.text.rpartition('.')[-1]\n",
     "                    for o in self.completions(c, len(c))\n",
-    "                    if o.type=='<unknown>']"
+    "                    if o.type not in ('magic', 'path')]"
    ]
   },
   {

--- a/nbs/02_shell.ipynb
+++ b/nbs/02_shell.ipynb
@@ -763,11 +763,11 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def render_outputs(outputs):\n",
+    "def render_outputs(outputs, ansi_renderer=strip_ansi):\n",
     "    def render_output(out):\n",
     "        otype = out['output_type']\n",
     "        if otype == 'stream':\n",
-    "            txt = strip_ansi(''.join(out['text']))\n",
+    "            txt = ansi_renderer(''.join(out['text']))\n",
     "            return f\"<pre>{txt}</pre>\" if out['name']=='stdout' else f\"<pre class='stderr'>{txt}</pre>\"\n",
     "        elif otype in ('display_data','execute_result'):\n",
     "            data = out['data']\n",
@@ -794,11 +794,11 @@
      "data": {
       "text/html": [
        "<pre>---------------------------------------------------------------------------\n",
-       "ZeroDivisionError                         Traceback (most recent call last)\n",
-       "File <ipython-input-1-9e1622b385b6>:1\n",
-       "----> 1 1/0\n",
+       "Exception                                 Traceback (most recent call last)\n",
+       "File <ipython-input-1-01648acb07bd>:1\n",
+       "----> 1 raise Exception(\"Oops\")\n",
        "\n",
-       "ZeroDivisionError: division by zero\n",
+       "Exception: Oops\n",
        "</pre>\n"
       ],
       "text/plain": [
@@ -812,6 +812,42 @@
    ],
    "source": [
     "HTML(render_outputs(o))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use `ansi2html` to convert from ANSI to HTML for color rendering.  You need some [css styles](https://github.com/fastai/fastcore/blob/master/examples/ansi.css) for the colors to render properly.  Jupyter already has these built in so it's not neccessary here, but if you plan on using this in another web app you will need to ensure that css styling is included."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre><span class=\"ansi-red-fg\">---------------------------------------------------------------------------</span>\n",
+       "<span class=\"ansi-red-fg\">Exception</span>                                 Traceback (most recent call last)\n",
+       "File <span class=\"ansi-green-fg\">&lt;ipython-input-1-01648acb07bd&gt;:1</span>\n",
+       "<span class=\"ansi-green-fg\">----&gt; 1</span> <span class=\"ansi-bold\" style=\"color: rgb(0,135,0)\">raise</span> <span class=\"ansi-bold\" style=\"color: rgb(215,95,95)\">Exception</span>(<span style=\"color: rgb(175,0,0)\">&#34;</span><span style=\"color: rgb(175,0,0)\">Oops</span><span style=\"color: rgb(175,0,0)\">&#34;</span>)\n",
+       "\n",
+       "<span class=\"ansi-red-fg\">Exception</span>: Oops\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "HTML(render_outputs(o, ansi2html))"
    ]
   },
   {


### PR DESCRIPTION
I added option to use different renderers in render_output and add examples of ansi2html.  I used this in a downstream app successfully.  However a couple things that may need to be resolved:

1. `markupsafe` is needed in fastcore for ansi2html.  Should this be a dependency in fastcore?  Or should that import be moved into the ansi2html function to make it an optional fastcore dependency?
1. There are other failing tests, but it looks like they have been failing for a couple weeks.  Are those tests still valid?